### PR TITLE
Fix StatsTool initial update

### DIFF
--- a/Assets/UnityForge-Toolkit/Editor/Tools/StatsTool.cs
+++ b/Assets/UnityForge-Toolkit/Editor/Tools/StatsTool.cs
@@ -31,6 +31,13 @@ namespace UnityForge.Tools
             modules.Add(new MemoryStatsModule());
 
             moduleNames = modules.ConvertAll(m => m.Name).ToArray();
+
+            // Update modules once so initial stats are populated when
+            // the window first opens
+            foreach (var module in modules)
+            {
+                module.Update();
+            }
         }
 
         public void OnGUI()


### PR DESCRIPTION
## Summary
- ensure StatsTool populates module data when opening the window

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_683f3a22028883278bfc3465c33112ae