### PR TITLE
Quick Tool Update

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -403,7 +403,7 @@ BoxCollider:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 425755766}
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 1488324102}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -478,7 +478,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 425755766}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 14.09, y: -2.8200336, z: -9.651737}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -545,7 +545,6 @@ GameObject:
   - component: {fileID: 965880302}
   - component: {fileID: 965880301}
   - component: {fileID: 965880300}
-  - component: {fileID: 965880299}
   m_Layer: 0
   m_Name: Box 1 (2)
   m_TagString: Untagged
@@ -553,27 +552,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!65 &965880299
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 965880298}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &965880300
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -635,13 +613,26 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 965880298}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 9.79, y: -2.8200336, z: -9.651737}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!134 &1488324102
+PhysicsMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_DynamicFriction: 0.6
+  m_StaticFriction: 0.6
+  m_Bounciness: 0
+  m_FrictionCombine: 0
+  m_BounceCombine: 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/UnityForge-Toolkit/Editor/Material/UV_Checker.mat
+++ b/Assets/UnityForge-Toolkit/Editor/Material/UV_Checker.mat
@@ -39,7 +39,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _BaseMap:
-        m_Texture: {fileID: 2800000, guid: d6a1a7f4de2dbc04fbdf00d598d7b2d6, type: 3}
+        m_Texture: {fileID: 2800000, guid: 64dd5e6dc92744f4fa3c5b93d9b7adb6, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BumpMap:

--- a/Assets/UnityForge-Toolkit/Editor/Tools/ObjectFinderTool.cs
+++ b/Assets/UnityForge-Toolkit/Editor/Tools/ObjectFinderTool.cs
@@ -129,9 +129,7 @@ namespace UnityForge.Tools
                 return;
             }
 
-            Object.FindObjectsByType<Collider>(FindObjectsSortMode.None);
-
-
+            var all = Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None);
             var refMesh = _reference.GetComponent<MeshFilter>()?.sharedMesh;
             var refMat = _reference.GetComponent<Renderer>()?.sharedMaterial;
             var refTypes = _reference.GetComponents<MonoBehaviour>().Select(c => c.GetType()).ToList();

--- a/Assets/UnityForge-Toolkit/Editor/Tools/QuickTool.cs
+++ b/Assets/UnityForge-Toolkit/Editor/Tools/QuickTool.cs
@@ -7,37 +7,80 @@ namespace UnityForge.Tools
     public class QuickTool : IUnityForgeTool
     {
         public string Name => "Quick";
-
-        private bool _showQuickTools = true;
-        private bool _showColliderChecker = true;
-        private bool _showSceneCleanup = true;
-        private bool _showStaticChecker = true;
+        public string DisplayName => "Quick Tool Section"; // GUI-Zweck
+        private bool _showQuickTools = false;
+        private bool _showColliderChecker = false;
+        private bool _showSceneCleanup = false;
+        private bool _showStaticChecker = false;
 
         private Vector2 _colliderScroll;
         private GameObject[] _skewedColliders = new GameObject[0];
 
         private Vector2 _staticCheckerScroll;
         private GameObject[] _nonStaticObjects = new GameObject[0];
+        private MonoScript _scriptAssetToAdd;
+        
+        private int _selectedColliderType = 0;
+        private readonly string[] _colliderOptions = new string[] { "None", "BoxCollider", "SphereCollider", "CapsuleCollider", "MeshCollider" };
+        
+        private GameObject _componentCopySource;
+        private List<Component> _copiableComponents = new();
+        private Vector2 _componentScroll;
+        private List<bool> _componentCopyFlags = new();
+        private bool _showResetItem = false;
+
+
 
         public void OnGUI()
-        {
-            DrawResetItemTool();
-            _showQuickTools = EditorGUILayout.Foldout(_showQuickTools, "Quick Tools", true);
-            if (_showQuickTools)
-                DrawGroupTools();
+{
+    // ▸ Modify Item (einklappbar oben)
+    _showResetItem = EditorGUILayout.Foldout(_showResetItem, "Modify Item", true);
+    if (_showResetItem)
+        DrawResetItemTool();
 
-            _showColliderChecker = EditorGUILayout.Foldout(_showColliderChecker, "Collider Checker", true);
-            if (_showColliderChecker)
-                DrawColliderChecker();
+    EditorGUILayout.Space(10);
 
-            _showSceneCleanup = EditorGUILayout.Foldout(_showSceneCleanup, "Scene Cleanup", true);
-            if (_showSceneCleanup)
-                DrawSceneCleanup();
+    // ▸ Erste Zeile: Group Tools & Collider Checker (nebeneinander)
+    EditorGUILayout.BeginHorizontal();
 
-            _showStaticChecker = EditorGUILayout.Foldout(_showStaticChecker, "Static Checker", true);
-            if (_showStaticChecker)
-                DrawStaticChecker();
-        }
+    // ▸ Group Tools Box (linke Spalte)
+    EditorGUILayout.BeginVertical(GUI.skin.box, GUILayout.Width(EditorGUIUtility.currentViewWidth / 2 - 25));
+    _showQuickTools = EditorGUILayout.Foldout(_showQuickTools, "Group Tools", true);
+    if (_showQuickTools)
+        DrawGroupTools();
+    EditorGUILayout.EndVertical();
+
+    // ▸ Collider Checker Box (rechte Spalte)
+    EditorGUILayout.BeginVertical(GUI.skin.box, GUILayout.Width(EditorGUIUtility.currentViewWidth / 2 - 25));
+    _showColliderChecker = EditorGUILayout.Foldout(_showColliderChecker, "Collider Checker", true);
+    if (_showColliderChecker)
+        DrawColliderChecker();
+    EditorGUILayout.EndVertical();
+
+    EditorGUILayout.EndHorizontal();
+
+    EditorGUILayout.Space(10);
+
+    // ▸ Zweite Zeile: Scene Cleanup & Static Checker (nebeneinander)
+    EditorGUILayout.BeginHorizontal();
+
+    // ▸ Scene Cleanup Box (linke Spalte)
+    EditorGUILayout.BeginVertical(GUI.skin.box, GUILayout.Width(EditorGUIUtility.currentViewWidth / 2 - 25));
+    _showSceneCleanup = EditorGUILayout.Foldout(_showSceneCleanup, "Scene Cleanup", true);
+    if (_showSceneCleanup)
+        DrawSceneCleanup();
+    EditorGUILayout.EndVertical();
+
+    // ▸ Static Checker Box (rechte Spalte)
+    EditorGUILayout.BeginVertical(GUI.skin.box, GUILayout.Width(EditorGUIUtility.currentViewWidth / 2 - 25));
+    _showStaticChecker = EditorGUILayout.Foldout(_showStaticChecker, "Static Checker", true);
+    if (_showStaticChecker)
+        DrawStaticChecker();
+    EditorGUILayout.EndVertical();
+
+    EditorGUILayout.EndHorizontal();
+}
+
 
         private bool _resetTransform = true;
         private bool _removeScripts = true;
@@ -47,53 +90,201 @@ namespace UnityForge.Tools
         private void DrawResetItemTool()
         {
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("Reset Item", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox("Reset selected GameObject to default state. You can choose which components to reset or remove.", MessageType.Info);
+            EditorGUILayout.LabelField("Modify Item", EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox("Modify selected GameObject to default state. Configure removals, additions, or transfer components from another object.", MessageType.Info);
 
+            EditorGUILayout.Space();
+            EditorGUILayout.BeginHorizontal();
+
+            // LEFT SIDE
+            EditorGUILayout.BeginVertical(GUILayout.Width(EditorGUIUtility.currentViewWidth / 2 - 30));
+
+            GUILayout.Label("Remove Components", EditorStyles.boldLabel);
             _resetTransform = EditorGUILayout.Toggle("Reset Transform", _resetTransform);
             _removeScripts = EditorGUILayout.Toggle("Remove Scripts", _removeScripts);
             _removeRenderers = EditorGUILayout.Toggle("Remove Renderers", _removeRenderers);
             _removeColliders = EditorGUILayout.Toggle("Remove Colliders", _removeColliders);
 
-            if (GUILayout.Button("Apply Reset to Selected") && Selection.activeGameObject != null)
+            GUILayout.Space(8);
+            if (GUILayout.Button("Remove Selected", GUILayout.Width(200)) && Selection.activeGameObject != null)
             {
-                ApplyReset(Selection.activeGameObject);
+                ApplyReset(Selection.activeGameObject, onlyRemove: true);
             }
+
+            GUILayout.Space(10);
+            GUILayout.Label("Add Components", EditorStyles.boldLabel);
+            _selectedColliderType = EditorGUILayout.Popup("Add Collider", _selectedColliderType, _colliderOptions);
+            _scriptAssetToAdd = (MonoScript)EditorGUILayout.ObjectField("Add Script", _scriptAssetToAdd, typeof(MonoScript), false);
+
+            GUILayout.Space(5);
+            if (GUILayout.Button("Add Components", GUILayout.Width(200)) && Selection.activeGameObject != null)
+            {
+                ApplyReset(Selection.activeGameObject, onlyAdd: true);
+            }
+
+            EditorGUILayout.EndVertical();
+
+            // VERTICAL SEPARATOR
+            GUILayout.Space(10);
+            EditorGUILayout.LabelField("", GUI.skin.verticalSlider, GUILayout.Width(1), GUILayout.ExpandHeight(true));
+            GUILayout.Space(10);
+
+            // RIGHT SIDE
+            EditorGUILayout.BeginVertical();
+
+            GUILayout.Label("Copy From Object", EditorStyles.boldLabel);
+            GameObject newSource = (GameObject)EditorGUILayout.ObjectField("Source", _componentCopySource, typeof(GameObject), true);
+            if (newSource != _componentCopySource)
+            {
+                _componentCopySource = newSource;
+                UpdateCopiableComponents();
+            }
+
+            GUILayout.Space(5);
+
+            if (_copiableComponents.Count > 0)
+            {
+                GUILayout.Label("Transferable Components:");
+                _componentScroll = EditorGUILayout.BeginScrollView(_componentScroll, GUILayout.Height(90));
+                for (int i = 0; i < _copiableComponents.Count; i++)
+                {
+                    var comp = _copiableComponents[i];
+                    if (comp == null) continue;
+
+                    EditorGUILayout.BeginHorizontal();
+                    _componentCopyFlags[i] = EditorGUILayout.Toggle(_componentCopyFlags[i], GUILayout.Width(20));
+                    EditorGUILayout.LabelField(comp.GetType().Name);
+                    EditorGUILayout.EndHorizontal();
+                }
+                EditorGUILayout.EndScrollView();
+            }
+            else
+            {
+                GUILayout.Label("No components to transfer.", EditorStyles.miniLabel);
+            }
+
+            GUILayout.Space(5);
+            GUI.enabled = _componentCopySource != null && _copiableComponents.Count > 0;
+            if (GUILayout.Button("Copy To Selected", GUILayout.Width(200)) && Selection.activeGameObject != null)
+            {
+                ApplyComponentCopyToTarget(_componentCopySource, Selection.activeGameObject);
+            }
+            GUI.enabled = true;
+
+            EditorGUILayout.EndVertical();
+
+            EditorGUILayout.EndHorizontal();
         }
 
-        private void ApplyReset(GameObject go)
-        {
-            if (_resetTransform)
-            {
-                Undo.RecordObject(go.transform, "Reset Transform");
-                go.transform.localPosition = Vector3.zero;
-                go.transform.localRotation = Quaternion.identity;
-                go.transform.localScale = Vector3.one;
-            }
 
-            if (_removeScripts)
+        
+        
+        private void ApplyCopiedComponents(GameObject source, GameObject target)
+        {
+            foreach (var comp in _copiableComponents)
             {
-                foreach (var comp in go.GetComponents<MonoBehaviour>())
+                if (comp == null) continue;
+                System.Type type = comp.GetType();
+
+                if (target.GetComponent(type) != null)
+                    continue; // nicht doppelt
+
+                Component newComp = Undo.AddComponent(target, type);
+
+                // Kopiere Felder
+                var fields = type.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                foreach (var field in fields)
                 {
-                    if (comp != null)
-                        Undo.DestroyObjectImmediate(comp);
+                    if (field.IsDefined(typeof(System.NonSerializedAttribute), true)) continue;
+                    field.SetValue(newComp, field.GetValue(comp));
+                }
+
+                // Kopiere Properties (optional)
+                var props = type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                foreach (var prop in props)
+                {
+                    if (!prop.CanWrite || !prop.CanRead || prop.Name == "name") continue;
+                    if (prop.GetIndexParameters().Length > 0) continue;
+                    try { prop.SetValue(newComp, prop.GetValue(comp)); }
+                    catch { /* überspringe inkompatible */ }
                 }
             }
 
-            if (_removeRenderers)
-            {
-                foreach (var renderer in go.GetComponents<Renderer>())
-                    Undo.DestroyObjectImmediate(renderer);
-            }
-
-            if (_removeColliders)
-            {
-                foreach (var collider in go.GetComponents<Collider>())
-                    Undo.DestroyObjectImmediate(collider);
-            }
-
-            UnityForgeWindow.AppendLogStatic($"Reset applied to: {go.name}");
+            UnityForgeWindow.AppendLogStatic($"Transferred {_copiableComponents.Count} component(s) to: {target.name}");
         }
+
+       private void ApplyReset(GameObject go, bool onlyRemove = false, bool onlyAdd = false)
+        {
+            if (!onlyAdd)
+            {
+                if (_resetTransform)
+                {
+                    Undo.RecordObject(go.transform, "Reset Transform");
+                    go.transform.localPosition = Vector3.zero;
+                    go.transform.localRotation = Quaternion.identity;
+                    go.transform.localScale = Vector3.one;
+                }
+
+                if (_removeScripts)
+                {
+                    foreach (var comp in go.GetComponents<MonoBehaviour>())
+                    {
+                        if (comp != null)
+                            Undo.DestroyObjectImmediate(comp);
+                    }
+                }
+
+                if (_removeRenderers)
+                {
+                    foreach (var renderer in go.GetComponents<Renderer>())
+                        Undo.DestroyObjectImmediate(renderer);
+                }
+
+                if (_removeColliders)
+                {
+                    foreach (var collider in go.GetComponents<Collider>())
+                        Undo.DestroyObjectImmediate(collider);
+                }
+            }
+
+            if (!onlyRemove)
+            {
+                // Add Collider
+                if (_selectedColliderType > 0)
+                {
+                    string typeName = "UnityEngine." + _colliderOptions[_selectedColliderType];
+                    var colliderType = System.Type.GetType(typeName + ", UnityEngine");
+                    if (colliderType != null && go.GetComponent(colliderType) == null)
+                    {
+                        Undo.AddComponent(go, colliderType);
+                    }
+                    else if (colliderType == null)
+                    {
+                        Debug.LogWarning("Collider type not found: " + typeName);
+                    }
+                }
+
+                // Add Script
+                if (_scriptAssetToAdd != null)
+                {
+                    var scriptType = _scriptAssetToAdd.GetClass();
+                    if (scriptType != null && scriptType.IsSubclassOf(typeof(MonoBehaviour)))
+                    {
+                        if (go.GetComponent(scriptType) == null)
+                            Undo.AddComponent(go, scriptType);
+                    }
+                    else
+                    {
+                        Debug.LogWarning("Selected script is not a valid MonoBehaviour: " + _scriptAssetToAdd.name);
+                    }
+                }
+
+
+            }
+
+            UnityForgeWindow.AppendLogStatic($"Reset/Add applied to: {go.name}");
+        }
+
 
 
         private void DrawGroupTools()
@@ -347,5 +538,62 @@ namespace UnityForge.Tools
             _nonStaticObjects = list.ToArray();
             UnityForgeWindow.AppendLogStatic($"Static Checker found {_nonStaticObjects.Length} non-static object(s).");
         }
+        
+        
+
+        private void UpdateCopiableComponents()
+        {
+            _copiableComponents.Clear();
+            _componentCopyFlags.Clear();
+
+            if (_componentCopySource == null) return;
+
+            foreach (var comp in _componentCopySource.GetComponents<Component>())
+            {
+                if (comp is Transform || comp is MeshFilter || comp is MeshRenderer)
+                    continue;
+                if (comp == null) continue;
+
+                _copiableComponents.Add(comp);
+                _componentCopyFlags.Add(true); // standardmäßig aktiviert
+            }
+        }
+
+
+        private void ApplyComponentCopyToTarget(GameObject source, GameObject target)
+{
+    for (int i = 0; i < _copiableComponents.Count; i++)
+    {
+        if (!_componentCopyFlags[i]) continue;
+
+        var comp = _copiableComponents[i];
+        if (comp == null) continue;
+
+        System.Type type = comp.GetType();
+        if (target.GetComponent(type) != null)
+            continue;
+
+        Component newComp = Undo.AddComponent(target, type);
+
+        var fields = type.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        foreach (var field in fields)
+        {
+            if (field.IsDefined(typeof(System.NonSerializedAttribute), true)) continue;
+            field.SetValue(newComp, field.GetValue(comp));
+        }
+
+        var props = type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        foreach (var prop in props)
+        {
+            if (!prop.CanWrite || !prop.CanRead || prop.Name == "name") continue;
+            if (prop.GetIndexParameters().Length > 0) continue;
+            try { prop.SetValue(newComp, prop.GetValue(comp)); }
+            catch { }
+        }
+    }
+
+    UnityForgeWindow.AppendLogStatic("Component transfer completed.");
+}
+
     }
 }


### PR DESCRIPTION
Refactored QuickTool UI with foldout structure and clean 2-column layout Group Tools, Collider Checker, Scene Cleanup, Static Checker now aligned in boxed sections Reset Item renamed to “Modify Item” and made collapsible Component transfer UI extended with checkbox selection per component Added drag field for source object + optional script/collider addition Copy logic respects checkbox state (selectively applied) Fixed layout misalignment and unified button widths Prevented foldout sections from auto-expanding by default Preserved internal tool Name short to avoid UI binding issues