### PR TITLE
Fix StatsTool initialization with new method

### DIFF
--- a/Assets/UnityForge-Toolkit/Editor/Tools/StatsTool.cs
+++ b/Assets/UnityForge-Toolkit/Editor/Tools/StatsTool.cs
@@ -11,6 +11,7 @@ namespace UnityForge.Tools
         private readonly List<StatsModuleBase> modules = new();
         private int selectedModule = 0;
         private string[] moduleNames;
+        private bool modulesInitialized = false;
 
         [MenuItem("Window/UnityForge/Stats", false, 100)]
         public static void ShowWindow()
@@ -21,6 +22,14 @@ namespace UnityForge.Tools
 
         private void OnEnable()
         {
+            InitializeModules();
+        }
+
+        public void InitializeModules()
+        {
+            if (modulesInitialized)
+                return;
+
             modules.Clear();
 
             modules.Add(new GeometryStatsModule());
@@ -38,10 +47,15 @@ namespace UnityForge.Tools
             {
                 module.Update();
             }
+
+            modulesInitialized = true;
         }
 
         public void OnGUI()
         {
+            if (!modulesInitialized)
+                InitializeModules();
+
             GUILayout.Space(5);
             GUILayout.Label("Select Module", EditorStyles.boldLabel);
             GUILayout.Space(5);

--- a/Assets/UnityForge-Toolkit/Editor/Windows/UnityForgeWindow.cs
+++ b/Assets/UnityForge-Toolkit/Editor/Windows/UnityForgeWindow.cs
@@ -182,6 +182,10 @@ EditorGUILayout.EndVertical();
             _activeTools.Clear();
             var type = _availableToolTypes[toolName];
             var inst = Activator.CreateInstance(type) as IUnityForgeTool;
+            if (inst is Tools.StatsTool statsTool)
+            {
+                statsTool.InitializeModules();
+            }
             if (inst != null)
                 _activeTools.Add(inst);
             _selectedTab = 0;


### PR DESCRIPTION
## Summary
- add flag and InitializeModules method to StatsTool
- call initialization from OnEnable and when GUI first draws
- ensure UnityForgeWindow calls InitializeModules when opening StatsTool

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f66e63e0483279afd4215f0c8b386